### PR TITLE
eorm: TableOf 必须要指定别名

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -2,6 +2,8 @@
 - [eorm: Distinct功能](https://github.com/gotomicro/eorm/pull/116)
 - [eorm: aop方案的支持](https://github.com/gotomicro/eorm/pull/117)
 - [eorm: 利用 aop 接口打印 SQL](https://github.com/gotomicro/eorm/pull/123)
+- [eorm: join查询](https://github.com/gotomicro/eorm/pull/122)
+- [eorm: 重构 JOIN 查询](https://github.com/gotomicro/eorm/pull/130)
 
 ## v0.0.1:
 - [Init Project](https://github.com/gotomicro/eorm/pull/1)
@@ -54,4 +56,3 @@
 - [Add examples and docs for Aggregate and Assign](https://github.com/gotomicro/eorm/pull/50)
 - [Add examples for Column and columns](https://github.com/gotomicro/eorm/pull/51)
 - [Add examples for DB, Predicate, Deleter, Inserter](https://github.com/gotomicro/eorm/pull/520)
-- [eorm: join查询](https://github.com/gotomicro/eorm/pull/122)

--- a/aggregate.go
+++ b/aggregate.go
@@ -23,7 +23,8 @@ type Aggregate struct {
 	distinct bool
 }
 
-// As specifies the alias
+// As 指定别名。一般情况下，这个别名应该等同于列名，我们会将这个列名映射过去对应的字段名。
+// 例如说 alias= avg_age，默认情况下，我们会找 AvgAge 这个字段来接收值。
 func (a Aggregate) As(alias string) Selectable {
 	return Aggregate{
 		fn:    a.fn,

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -26,42 +26,42 @@ func TestAggregate(t *testing.T) {
 	testCases := []CommonTestCase{
 		{
 			name:    "avg",
-			builder: NewSelector[TestModel](db).Select(Avg("Age")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Avg("Age")),
 			wantSql: "SELECT AVG(`age`) FROM `test_model`;",
 		},
 		{
 			name:    "max",
-			builder: NewSelector[TestModel](db).Select(Max("Age")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Max("Age")),
 			wantSql: "SELECT MAX(`age`) FROM `test_model`;",
 		},
 		{
 			name:    "min",
-			builder: NewSelector[TestModel](db).Select(Min("Age").As("min_age")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Min("Age").As("min_age")),
 			wantSql: "SELECT MIN(`age`) AS `min_age` FROM `test_model`;",
 		},
 		{
 			name:    "sum",
-			builder: NewSelector[TestModel](db).Select(Sum("Age")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Sum("Age")),
 			wantSql: "SELECT SUM(`age`) FROM `test_model`;",
 		},
 		{
 			name:    "count",
-			builder: NewSelector[TestModel](db).Select(Count("Age")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Count("Age")),
 			wantSql: "SELECT COUNT(`age`) FROM `test_model`;",
 		},
 		{
 			name:    "count distinct",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Select(CountDistinct("FirstName")),
+			builder: NewSelector[TestModel](db).Select(CountDistinct("FirstName")),
 			wantSql: "SELECT COUNT(DISTINCT `first_name`) FROM `test_model`;",
 		},
 		{
 			name:    "avg distinct",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Select(AvgDistinct("FirstName")),
+			builder: NewSelector[TestModel](db).Select(AvgDistinct("FirstName")),
 			wantSql: "SELECT AVG(DISTINCT `first_name`) FROM `test_model`;",
 		},
 		{
 			name:    "SUM distinct",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Select(SumDistinct("FirstName")),
+			builder: NewSelector[TestModel](db).Select(SumDistinct("FirstName")),
 			wantSql: "SELECT SUM(DISTINCT `first_name`) FROM `test_model`;",
 		},
 	}
@@ -82,42 +82,42 @@ func TestAggregate(t *testing.T) {
 
 func ExampleAggregate_As() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Avg("Age").As("avg_age")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(Avg("Age").As("avg_age")).Build()
 	fmt.Println(query.SQL)
 	// Output: SELECT AVG(`age`) AS `avg_age` FROM `test_model`;
 }
 
 func ExampleAvg() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Avg("Age").As("avg_age")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(Avg("Age").As("avg_age")).Build()
 	fmt.Println(query.SQL)
 	// Output: SELECT AVG(`age`) AS `avg_age` FROM `test_model`;
 }
 
 func ExampleCount() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Count("Age")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(Count("Age")).Build()
 	fmt.Println(query.SQL)
 	// Output: SELECT COUNT(`age`) FROM `test_model`;
 }
 
 func ExampleMax() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Max("Age")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(Max("Age")).Build()
 	fmt.Println(query.SQL)
 	// Output: SELECT MAX(`age`) FROM `test_model`;
 }
 
 func ExampleMin() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Min("Age")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(Min("Age")).Build()
 	fmt.Println(query.SQL)
 	// Output: SELECT MIN(`age`) FROM `test_model`;
 }
 
 func ExampleSum() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Sum("Age")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(Sum("Age")).Build()
 	fmt.Println(query.SQL)
 	// Output: SELECT SUM(`age`) FROM `test_model`;
 }

--- a/assignment.go
+++ b/assignment.go
@@ -14,7 +14,7 @@
 
 package eorm
 
-// Assignable represents that something could be used as "assignment" statement
+// Assignable represents that something could be used alias "assignment" statement
 type Assignable interface {
 	assign()
 }

--- a/column_test.go
+++ b/column_test.go
@@ -18,7 +18,7 @@ import "fmt"
 
 func ExampleC() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id")).From(TableOf(&TestModel{})).Where(C("Id").EQ(18)).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id")).Where(C("Id").EQ(18)).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -30,7 +30,7 @@ Args: %v
 
 func ExampleColumn_EQ() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id")).From(TableOf(&TestModel{})).Where(C("Id").EQ(18)).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id")).Where(C("Id").EQ(18)).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -55,7 +55,7 @@ Args: %v
 
 func ExampleColumn_As() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id").As("my_id")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id").As("my_id")).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -67,7 +67,7 @@ Args: %v
 
 func ExampleColumn_GT() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id")).From(TableOf(&TestModel{})).Where(C("Id").GT(18)).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id")).Where(C("Id").GT(18)).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -79,7 +79,7 @@ Args: %v
 
 func ExampleColumn_GTEQ() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id")).From(TableOf(&TestModel{})).Where(C("Id").GTEQ(18)).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id")).Where(C("Id").GTEQ(18)).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -91,7 +91,7 @@ Args: %v
 
 func ExampleColumn_LT() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id")).From(TableOf(&TestModel{})).Where(C("Id").LT(18)).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id")).Where(C("Id").LT(18)).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -103,7 +103,7 @@ Args: %v
 
 func ExampleColumn_LTEQ() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id")).From(TableOf(&TestModel{})).Where(C("Id").LTEQ(18)).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id")).Where(C("Id").LTEQ(18)).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -128,7 +128,7 @@ Args: %v
 
 func ExampleColumn_NEQ() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(C("Id")).From(TableOf(&TestModel{})).Where(C("Id").NEQ(18)).Build()
+	query, _ := NewSelector[TestModel](db).Select(C("Id")).Where(C("Id").NEQ(18)).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v
@@ -140,7 +140,7 @@ Args: %v
 
 func ExampleColumns() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Columns("Id", "Age")).From(TableOf(&TestModel{})).Build()
+	query, _ := NewSelector[TestModel](db).Select(Columns("Id", "Age")).Build()
 	fmt.Printf(`
 SQL: %s
 Args: %v

--- a/db_test.go
+++ b/db_test.go
@@ -188,7 +188,7 @@ func BenchmarkQuerier_Get(b *testing.B) {
 			Creator: valuer.NewUnsafeValue,
 		}
 		for i := 0; i < b.N; i++ {
-			_, err = NewSelector[TestModel](orm).From(TableOf(&TestModel{})).Get(context.Background())
+			_, err = NewSelector[TestModel](orm).From(TableOf(&TestModel{}, "t1")).Get(context.Background())
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -200,7 +200,7 @@ func BenchmarkQuerier_Get(b *testing.B) {
 			Creator: valuer.NewReflectValue,
 		}
 		for i := 0; i < b.N; i++ {
-			_, err = NewSelector[TestModel](orm).From(TableOf(&TestModel{})).Get(context.Background())
+			_, err = NewSelector[TestModel](orm).From(TableOf(&TestModel{}, "t1")).Get(context.Background())
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/expression.go
+++ b/expression.go
@@ -19,13 +19,13 @@ type Expr interface {
 	expr() (string, error)
 }
 
-// RawExpr uses string as Expr
+// RawExpr uses string alias Expr
 type RawExpr struct {
 	raw  string
 	args []interface{}
 }
 
-// Raw just take expr as Expr
+// Raw just take expr alias Expr
 func Raw(expr string, args ...interface{}) RawExpr {
 	return RawExpr{
 		raw:  expr,

--- a/expression_test.go
+++ b/expression_test.go
@@ -26,20 +26,20 @@ func TestRawExpr_AsPredicate(t *testing.T) {
 	testCases := []CommonTestCase{
 		{
 			name:     "simple",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(Raw("`id`<?", 12).AsPredicate()),
+			builder:  NewSelector[TestModel](db).Where(Raw("`id`<?", 12).AsPredicate()),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `id`<?;",
 			wantArgs: []interface{}{12},
 		},
 		{
 			name: "and",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(Raw("`id`<?", 12).AsPredicate().
+			builder: NewSelector[TestModel](db).Where(Raw("`id`<?", 12).AsPredicate().
 				And(Raw("`age`<?", 18).AsPredicate())),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE (`id`<?) AND (`age`<?);",
 			wantArgs: []interface{}{12, 18},
 		},
 		{
 			name: "Or",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(Raw("`id`<?", 12).AsPredicate().
+			builder: NewSelector[TestModel](db).Where(Raw("`id`<?", 12).AsPredicate().
 				Or(Raw("`age`<?", 18).AsPredicate())),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE (`id`<?) OR (`age`<?);",
 			wantArgs: []interface{}{12, 18},
@@ -62,7 +62,7 @@ func TestRawExpr_AsPredicate(t *testing.T) {
 
 func ExampleRawExpr_AsPredicate() {
 	pred := Raw("`id`<?", 12).AsPredicate()
-	query, _ := NewSelector[TestModel](memoryDB()).From(TableOf(&TestModel{})).Where(pred).Build()
+	query, _ := NewSelector[TestModel](memoryDB()).Where(pred).Build()
 	fmt.Println(query.string())
 	// Output:
 	// SQL: SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `id`<?;

--- a/internal/errs/error.go
+++ b/internal/errs/error.go
@@ -17,7 +17,6 @@ package errs
 import (
 	"errors"
 	"fmt"
-	"reflect"
 )
 
 var (
@@ -54,22 +53,16 @@ func NewValueNotSetError() error {
 	return errValueNotSet
 }
 
-// NewUnsupportedTypeError 不支持的字段类型
-// 请参阅 https://github.com/gotomicro/eorm/discussions/71
-func NewUnsupportedTypeError(typ reflect.Type) error {
-	return fmt.Errorf("eorm: 不支持字段类型 %s, %s", typ.PkgPath(), typ.Name())
-}
-
 // NewUnsupportedDriverError 不支持驱动类型
 func NewUnsupportedDriverError(driver string) error {
 	return fmt.Errorf("eorm: 不支持driver类型 %s", driver)
 }
 
-// NewErrUnsupportedTable 不支持的TableReference类型
-func NewErrUnsupportedTable(table any) error {
+// NewUnsupportedTableReferenceError 不支持的TableReference类型
+func NewUnsupportedTableReferenceError(table any) error {
 	return fmt.Errorf("eorm: 不支持的TableReference类型 %v", table)
 }
 
-func NewErrUnknownField(name string) error {
-	return fmt.Errorf("eorm: 未知字段 %s", name)
+func NewMustSpecifyColumnsError() error {
+	return fmt.Errorf("eorm: 复合查询如 JOIN 查询、子查询必须指定要查找的列，即指定 SELECT xxx 部分")
 }

--- a/internal/integration/select_combination_test.go
+++ b/internal/integration/select_combination_test.go
@@ -55,17 +55,13 @@ func (s *SelectCombinationTestSuite) TestGet() {
 		wantRes *test.CombinedModel
 	}{
 		{
-			name: "not found",
-			s: eorm.NewSelector[test.CombinedModel](s.orm).
-				From(&test.CombinedModel{}).
-				Where(eorm.C("Id").EQ(9)),
+			name:    "not found",
+			s:       eorm.NewSelector[test.CombinedModel](s.orm).Where(eorm.C("Id").EQ(9)),
 			wantErr: eorm.ErrNoRows,
 		},
 		{
-			name: "found",
-			s: eorm.NewSelector[test.CombinedModel](s.orm).
-				From(&test.CombinedModel{}).
-				Where(eorm.C("Id").EQ(1)),
+			name:    "found",
+			s:       eorm.NewSelector[test.CombinedModel](s.orm).Where(eorm.C("Id").EQ(1)),
 			wantRes: s.data,
 		},
 	}

--- a/internal/integration/select_test.go
+++ b/internal/integration/select_test.go
@@ -19,9 +19,10 @@ package integration
 import (
 	"context"
 	"database/sql"
+	"testing"
+
 	"github.com/gotomicro/eorm/internal/errs"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	"github.com/gotomicro/eorm"
 	"github.com/gotomicro/eorm/internal/test"
@@ -61,14 +62,12 @@ func (s *SelectTestSuite) TestSelectorGet() {
 		{
 			name: "not found",
 			s: eorm.NewSelector[test.SimpleStruct](s.orm).
-				From(eorm.TableOf(&test.SimpleStruct{})).
 				Where(eorm.C("Id").EQ(9)),
 			wantErr: eorm.ErrNoRows,
 		},
 		{
 			name: "found",
 			s: eorm.NewSelector[test.SimpleStruct](s.orm).
-				From(eorm.TableOf(&test.SimpleStruct{})).
 				Where(eorm.C("Id").EQ(1)),
 			wantRes: s.data,
 		},
@@ -106,7 +105,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res int",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[int](s.orm).Select(eorm.C("Id")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *int {
@@ -118,7 +118,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res string",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[string](s.orm).Select(eorm.C("String")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *string {
@@ -130,7 +131,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res bytes",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[[]byte](s.orm).Select(eorm.C("ByteArray")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *[]byte {
@@ -142,7 +144,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res bool",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[bool](s.orm).Select(eorm.C("Bool")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *bool {
@@ -154,7 +157,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res null string ptr",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[sql.NullString](s.orm).Select(eorm.C("NullStringPtr")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *sql.NullString {
@@ -166,7 +170,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res null int32 ptr",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[sql.NullInt32](s.orm).Select(eorm.C("NullInt32Ptr")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *sql.NullInt32 {
@@ -178,7 +183,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res null bool ptr",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[sql.NullBool](s.orm).Select(eorm.C("NullBoolPtr")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *sql.NullBool {
@@ -190,7 +196,8 @@ func (s *SelectTestSuite) TestSelectorGetBaseType() {
 			name: "res null float64 ptr",
 			queryRes: func() (any, error) {
 				queryer := eorm.NewSelector[sql.NullFloat64](s.orm).Select(eorm.C("NullFloat64Ptr")).
-					From(eorm.TableOf(&test.SimpleStruct{})).Where(eorm.C("Id").EQ(1))
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).
+					Where(eorm.C("Id").EQ(1))
 				return queryer.Get(context.Background())
 			},
 			wantRes: func() *sql.NullFloat64 {
@@ -431,14 +438,12 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMulti() {
 		{
 			name: "not found",
 			s: eorm.NewSelector[test.SimpleStruct](s.orm).
-				From(eorm.TableOf(&test.SimpleStruct{})).
 				Where(eorm.C("Id").EQ(9)),
 			wantRes: []*test.SimpleStruct{},
 		},
 		{
 			name: "found",
 			s: eorm.NewSelector[test.SimpleStruct](s.orm).
-				From(eorm.TableOf(&test.SimpleStruct{})).
 				Where(eorm.C("Id").LT(4)),
 			wantRes: s.data,
 		},
@@ -466,8 +471,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res int",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[int](s.orm).Select(eorm.C("Id")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[int](s.orm).Select(eorm.C("Id")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: func() (res []*int) {
@@ -481,8 +485,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res string",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[string](s.orm).Select(eorm.C("String")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[string](s.orm).Select(eorm.C("String")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: func() (res []*string) {
@@ -496,8 +499,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res bytes",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[[]byte](s.orm).Select(eorm.C("ByteArray")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[[]byte](s.orm).Select(eorm.C("ByteArray")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: func() (res []*[]byte) {
@@ -511,8 +513,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res bool",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[bool](s.orm).Select(eorm.C("Bool")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[bool](s.orm).Select(eorm.C("Bool")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: func() (res []*bool) {
@@ -526,8 +527,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res null string ptr",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[sql.NullString](s.orm).Select(eorm.C("NullStringPtr")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[sql.NullString](s.orm).Select(eorm.C("NullStringPtr")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: []*sql.NullString{
@@ -548,8 +548,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res null int32 ptr",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[sql.NullInt32](s.orm).Select(eorm.C("NullInt32Ptr")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[sql.NullInt32](s.orm).Select(eorm.C("NullInt32Ptr")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: []*sql.NullInt32{
@@ -570,8 +569,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res null bool ptr",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[sql.NullBool](s.orm).Select(eorm.C("NullBoolPtr")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[sql.NullBool](s.orm).Select(eorm.C("NullBoolPtr")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: []*sql.NullBool{
@@ -592,8 +590,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorGetMultiBaseType() {
 		{
 			name: "res null float64 ptr",
 			queryRes: func() (any, error) {
-				queryer := eorm.NewSelector[sql.NullFloat64](s.orm).Select(eorm.C("NullFloat64Ptr")).
-					From(eorm.TableOf(&test.SimpleStruct{}))
+				queryer := eorm.NewSelector[sql.NullFloat64](s.orm).Select(eorm.C("NullFloat64Ptr")).From(eorm.TableOf(&test.SimpleStruct{}, "t1"))
 				return queryer.GetMulti(context.Background())
 			},
 			wantRes: []*sql.NullFloat64{
@@ -734,7 +731,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorDistinct() {
 		{
 			name: "distinct col",
 			s: func() (any, error) {
-				return eorm.NewSelector[test.SimpleStruct](s.orm).From(eorm.TableOf(&test.SimpleStruct{})).Select(eorm.C("Int")).Distinct().GetMulti(context.Background())
+				return eorm.NewSelector[test.SimpleStruct](s.orm).Select(eorm.C("Int")).Distinct().GetMulti(context.Background())
 
 			},
 			wantRes: []*test.SimpleStruct{
@@ -746,7 +743,8 @@ func (s *SelectTestSuiteGetMulti) TestSelectorDistinct() {
 		{
 			name: "count distinct",
 			s: func() (any, error) {
-				return eorm.NewSelector[int](s.orm).Select(eorm.CountDistinct("Bool")).From(eorm.TableOf(&test.SimpleStruct{})).GetMulti(context.Background())
+				return eorm.NewSelector[int](s.orm).Select(eorm.CountDistinct("Bool")).
+					From(eorm.TableOf(&test.SimpleStruct{}, "t1")).GetMulti(context.Background())
 			},
 			wantRes: func() []*int {
 				val := 1
@@ -756,7 +754,7 @@ func (s *SelectTestSuiteGetMulti) TestSelectorDistinct() {
 		{
 			name: "having count distinct",
 			s: func() (any, error) {
-				return eorm.NewSelector[test.SimpleStruct](s.orm).From(eorm.TableOf(&test.SimpleStruct{})).Select(eorm.C("JsonColumn")).GroupBy("JsonColumn").Having(eorm.CountDistinct("JsonColumn").EQ(1)).GetMulti(context.Background())
+				return eorm.NewSelector[test.SimpleStruct](s.orm).Select(eorm.C("JsonColumn")).GroupBy("JsonColumn").Having(eorm.CountDistinct("JsonColumn").EQ(1)).GetMulti(context.Background())
 			},
 			wantRes: []*test.SimpleStruct{
 				&test.SimpleStruct{
@@ -830,48 +828,48 @@ func (s *SelectTestSuiteJoin) TestSelectorJoin() {
 		{
 			name: "join",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).Using("UsingCol1", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantRes: &test.Order{Id: 1, UsingCol1: "usingcoa1_1", UsingCol2: "usingcoa1_2"},
 		},
 		{
 			name: "join As",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{}).As("t1")
-				t2 := eorm.TableOf(&test.OrderDetail{}).As("t2")
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantRes: &test.Order{Id: 1, UsingCol1: "usingcoa1_1", UsingCol2: "usingcoa1_2"},
 		},
 		{
 			name: "join using col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantRes: &test.Order{Id: 1, UsingCol1: "usingcoa1_1", UsingCol2: "usingcoa1_2"},
 		},
 		{
 			name: "join using invalid col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("invalid", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantErr: errs.NewInvalidFieldError("invalid"),
 		},
 		{
 			name: "join Avg",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{}).As("t1")
-				t2 := eorm.TableOf(&test.OrderDetail{}).As("t2")
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.Avg("UsingCol1").As("using_col1"), t1.Avg("UsingCol2").As("using_col2")).Get(context.Background())
 			},
@@ -880,8 +878,8 @@ func (s *SelectTestSuiteJoin) TestSelectorJoin() {
 		{
 			name: "join Avg invalid",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{}).As("t1")
-				t2 := eorm.TableOf(&test.OrderDetail{}).As("t2")
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.Avg("invalid").As("using_col1"), t1.Avg("UsingCol2").As("using_col2")).Get(context.Background())
 			},
@@ -890,8 +888,8 @@ func (s *SelectTestSuiteJoin) TestSelectorJoin() {
 		{
 			name: "join col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{}).As("t1")
-				t2 := eorm.TableOf(&test.OrderDetail{}).As("t2")
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.C("UsingCol1"), t2.C("UsingCol2")).Get(context.Background())
 			},
@@ -900,8 +898,8 @@ func (s *SelectTestSuiteJoin) TestSelectorJoin() {
 		{
 			name: "join col invalid",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{}).As("t1")
-				t2 := eorm.TableOf(&test.OrderDetail{}).As("t2")
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.C("invalid"), t2.C("UsingCol2")).Get(context.Background())
 			},
@@ -952,18 +950,18 @@ func (s *SelectTestSuiteLeftJoin) TestSelectorLeftJoin() {
 		{
 			name: "left join",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).Using("UsingCol1", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantRes: &test.Order{Id: 1, UsingCol1: "usingcoa1_1", UsingCol2: "usingcoa1_2"},
 		},
 		{
 			name: "left join col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.C("UsingCol1")).Get(context.Background())
 			},
@@ -972,8 +970,8 @@ func (s *SelectTestSuiteLeftJoin) TestSelectorLeftJoin() {
 		{
 			name: "left join invalid col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.C("invalid")).Get(context.Background())
 			},
@@ -982,28 +980,28 @@ func (s *SelectTestSuiteLeftJoin) TestSelectorLeftJoin() {
 		{
 			name: "left join using col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).Using("UsingCol1", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantRes: &test.Order{Id: 1, UsingCol1: "usingcoa1_1", UsingCol2: "usingcoa1_2"},
 		},
 		{
 			name: "left join using invalid col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).Using("invalid", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantErr: errs.NewInvalidFieldError("invalid"),
 		},
 		{
 			name: "left join Avg ",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).Using("UsingCol1", "UsingCol2")
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.Avg("UsingCol1").As("using_col1")).Get(context.Background())
 			},
@@ -1012,8 +1010,8 @@ func (s *SelectTestSuiteLeftJoin) TestSelectorLeftJoin() {
 		{
 			name: "left join Avg invalid",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).Using("UsingCol1", "UsingCol2")
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.Avg("invalid").As("using_col1")).Get(context.Background())
 			},
@@ -1062,18 +1060,18 @@ func (s *SelectTestSuiteRightJoin) TestSelectorRightJoin() {
 		{
 			name: "Right join",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.RightJoin(t2).Using("UsingCol1", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantRes: &test.Order{Id: 1, UsingCol1: "usingcoa1_1", UsingCol2: "usingcoa1_2"},
 		},
 		{
 			name: "right join col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.RightJoin(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.C("UsingCol1")).Get(context.Background())
 			},
@@ -1082,8 +1080,8 @@ func (s *SelectTestSuiteRightJoin) TestSelectorRightJoin() {
 		{
 			name: "right join invalid col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.RightJoin(t2).Using("UsingCol1", "UsingCol2")
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.C("invalid")).Get(context.Background())
 			},
@@ -1092,28 +1090,28 @@ func (s *SelectTestSuiteRightJoin) TestSelectorRightJoin() {
 		{
 			name: "right join using col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.RightJoin(t2).Using("UsingCol1", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantRes: &test.Order{Id: 1, UsingCol1: "usingcoa1_1", UsingCol2: "usingcoa1_2"},
 		},
 		{
 			name: "right join using invalid col",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.RightJoin(t2).Using("invalid", "UsingCol2")
-				return eorm.NewSelector[test.Order](s.orm).From(t3).Get(context.Background())
+				return eorm.NewSelector[test.Order](s.orm).Select(t1.AllColumns()).From(t3).Get(context.Background())
 			},
 			wantErr: errs.NewInvalidFieldError("invalid"),
 		},
 		{
 			name: "right join Avg",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.RightJoin(t2).Using("UsingCol1", "UsingCol2")
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.Avg("UsingCol1").As("using_col1")).Get(context.Background())
 			},
@@ -1122,8 +1120,8 @@ func (s *SelectTestSuiteRightJoin) TestSelectorRightJoin() {
 		{
 			name: "right join Avg invalid",
 			s: func() (any, error) {
-				t1 := eorm.TableOf(&test.Order{})
-				t2 := eorm.TableOf(&test.OrderDetail{})
+				t1 := eorm.TableOf(&test.Order{}, "t1")
+				t2 := eorm.TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.RightJoin(t2).Using("UsingCol1", "UsingCol2")
 				return eorm.NewSelector[test.Order](s.orm).From(t3).Select(t1.Avg("invalid").As("using_col1")).Get(context.Background())
 			},

--- a/internal/test/types.go
+++ b/internal/test/types.go
@@ -125,7 +125,7 @@ func (j *JsonColumn) Scan(src any) error {
 
 // Value 参考 sql.NullXXX 类型定义的
 func (j *JsonColumn) Value() (driver.Value, error) {
-	if !j.Valid {
+	if j == nil || !j.Valid {
 		return nil, nil
 	}
 	bs, err := json.Marshal(j.Val)

--- a/predicate_test.go
+++ b/predicate_test.go
@@ -27,105 +27,105 @@ func TestPredicate_C(t *testing.T) {
 	testCases := []CommonTestCase{
 		{
 			name:    "empty",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).Where(),
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).Where(),
 			wantSql: "SELECT `id` FROM `test_model`;",
 		},
 		{
 			name: "multiples",
 			// 在传入多个 Predicate 的时候，我们认为它们是用 and 连接起来的
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(C("Id").LT(13), C("Id").GT(4)),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE (`id`<?) AND (`id`>?);",
 			wantArgs: []interface{}{13, 4},
 		},
 		{
 			name: "and",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(C("Id").LT(13).And(C("Id").GT(4))),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE (`id`<?) AND (`id`>?);",
 			wantArgs: []interface{}{13, 4},
 		},
 		{
 			name: "or",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(C("Id").LT(13).Or(C("Id").GT(4))),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE (`id`<?) OR (`id`>?);",
 			wantArgs: []interface{}{13, 4},
 		},
 		{
 			name: "not",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(Not(C("Id").LT(13).Or(C("Id").GT(4)))),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE NOT ((`id`<?) OR (`id`>?));",
 			wantArgs: []interface{}{13, 4},
 		},
 		{
 			name: "and or",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(C("Id").LT(13).Or(C("Id").GT(4)).And(C("FirstName").GT("tom"))),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE ((`id`<?) OR (`id`>?)) AND (`first_name`>?);",
 			wantArgs: []interface{}{13, 4, "tom"},
 		},
 		{
 			name: "cross columns",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(C("Id").LT(13).Or(C("Age").GT(C("Id")))),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE (`id`<?) OR (`age`>`id`);",
 			wantArgs: []interface{}{13},
 		},
 		{
 			name: "cross columns mathematical",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(C("Age").GT(C("Id").Add(40))),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE `age`>(`id`+?);",
 			wantArgs: []interface{}{40},
 		},
 		{
 			name: "cross columns mathematical",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).
 				Where(C("Age").GT(C("Id").Multi(C("Age").Add(66)))),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE `age`>(`id`*(`age`+?));",
 			wantArgs: []interface{}{66},
 		},
 		{
 			name:     "Avg with EQ",
-			builder:  NewSelector[TestModel](db).Select().From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Avg("Age").EQ(18)),
+			builder:  NewSelector[TestModel](db).Select().GroupBy("FirstName").Having(Avg("Age").EQ(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING AVG(`age`)=?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:     "Max with NEQ",
-			builder:  NewSelector[TestModel](db).Select().From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Max("Age").NEQ(18)),
+			builder:  NewSelector[TestModel](db).Select().GroupBy("FirstName").Having(Max("Age").NEQ(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING MAX(`age`)!=?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:     "Min with LT",
-			builder:  NewSelector[TestModel](db).Select().From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Min("Age").LT(18)),
+			builder:  NewSelector[TestModel](db).Select().GroupBy("FirstName").Having(Min("Age").LT(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING MIN(`age`)<?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:     "Sum with LTEQ",
-			builder:  NewSelector[TestModel](db).Select().From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Sum("Age").LTEQ(18)),
+			builder:  NewSelector[TestModel](db).Select().GroupBy("FirstName").Having(Sum("Age").LTEQ(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING SUM(`age`)<=?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:     "Count with GT",
-			builder:  NewSelector[TestModel](db).Select().From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Count("Age").GT(18)),
+			builder:  NewSelector[TestModel](db).Select().GroupBy("FirstName").Having(Count("Age").GT(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING COUNT(`age`)>?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:     "Avg with GTEQ",
-			builder:  NewSelector[TestModel](db).Select().From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Avg("Age").GTEQ(18)),
+			builder:  NewSelector[TestModel](db).Select().GroupBy("FirstName").Having(Avg("Age").GTEQ(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING AVG(`age`)>=?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:     "multiples aggregate functions",
-			builder:  NewSelector[TestModel](db).Select().From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Avg("Age").GTEQ(18).And(Sum("Age").LTEQ(30))),
+			builder:  NewSelector[TestModel](db).Select().GroupBy("FirstName").Having(Avg("Age").GTEQ(18).And(Sum("Age").LTEQ(30))),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING (AVG(`age`)>=?) AND (SUM(`age`)<=?);",
 			wantArgs: []interface{}{18, 30},
 		},
@@ -173,7 +173,7 @@ type CommonTestCase struct {
 
 func ExampleNot() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).Where(Not(C("Id").EQ(18))).Build()
+	query, _ := NewSelector[TestModel](db).Select(Columns("Id")).Where(Not(C("Id").EQ(18))).Build()
 	fmt.Println(query.string())
 	// Output:
 	// SQL: SELECT `id` FROM `test_model` WHERE NOT (`id`=?);
@@ -182,7 +182,7 @@ func ExampleNot() {
 
 func ExamplePredicate_And() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{Id: 10})).Where(C("Id").EQ(18).And(C("Age").GT(100))).Build()
+	query, _ := NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").EQ(18).And(C("Age").GT(100))).Build()
 	fmt.Println(query.string())
 	// Output:
 	// SQL: SELECT `id` FROM `test_model` WHERE (`id`=?) AND (`age`>?);
@@ -191,9 +191,7 @@ func ExamplePredicate_And() {
 
 func ExamplePredicate_Or() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{
-		Id: 10,
-	})).Where(C("Id").EQ(18).Or(C("Age").GT(100))).Build()
+	query, _ := NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").EQ(18).Or(C("Age").GT(100))).Build()
 	fmt.Println(query.string())
 	// Output:
 	// SQL: SELECT `id` FROM `test_model` WHERE (`id`=?) OR (`age`>?);

--- a/script/mysql/init.sql
+++ b/script/mysql/init.sql
@@ -1,3 +1,56 @@
+create database if not exists `integration_test`;
+create table if not exists `integration_test`.`simple_struct`
+(
+    `id` bigint auto_increment,
+    bool smallint not null,
+    bool_ptr smallint,
+    `int` int not null,
+    int_ptr int,
+    `int8` smallint not null,
+    int8_ptr smallint,
+    int16 int not null,
+    int16_ptr int,
+    int32 int not null,
+    int32_ptr int,
+    int64 bigint not null,
+    int64_ptr bigint,
+    uint int not null,
+    uint_ptr int,
+    uint8 int not null,
+    uint8_ptr int,
+    uint16 int not null,
+    uint16_ptr int,
+    uint32 int not null,
+    uint32_ptr int,
+    uint64 bigint not null,
+    uint64_ptr bigint,
+    float32 float not null,
+    float32_ptr float,
+    float64 float not null,
+    float64_ptr float,
+    byte_array varchar(1024),
+    string varchar(1024) not null,
+    null_string_ptr varchar(1024),
+    null_int16_ptr int,
+    null_int32_ptr int,
+    null_int64_ptr int,
+    null_bool_ptr smallint,
+    null_time_ptr datetime,
+    null_float64_ptr float,
+    json_column varchar(2048),
+    primary key (`id`)
+);
+
+create table if not exists `integration_test`.`combined_model`
+(
+    `id`          bigint auto_increment
+    primary key,
+    `first_name`  varchar(128) null,
+    `age`         int          null,
+    `last_name`   varchar(128) null,
+    `create_time` bigint       null,
+    `update_time` bigint       null
+    );
 create table if not exists `integration_test`.`order`
 (
     `id`          bigint auto_increment

--- a/select.go
+++ b/select.go
@@ -16,6 +16,7 @@ package eorm
 
 import (
 	"context"
+
 	"github.com/gotomicro/eorm/internal/errs"
 	"github.com/valyala/bytebufferpool"
 )
@@ -46,13 +47,14 @@ func NewSelector[T any](sess session) *Selector[T] {
 	}
 }
 
-// TableOf -> get selector table
+// tableOf -> get selector table
 func (s *Selector[T]) tableOf() any {
 	switch tb := s.table.(type) {
 	case Table:
 		return tb.entity
 	default:
-		return new(T)
+		// 不使用 new(T) 来规避内存分配
+		return (*T)(nil)
 	}
 }
 
@@ -69,8 +71,13 @@ func (s *Selector[T]) Build() (*Query, error) {
 		s.writeString("DISTINCT ")
 	}
 	if len(s.columns) == 0 {
-		if err := s.buildAllColumns(); err != nil {
-			return nil, err
+		switch s.table.(type) {
+		case Table, nil:
+			if err = s.buildAllColumns(); err != nil {
+				return nil, err
+			}
+		default:
+			return nil, errs.NewMustSpecifyColumnsError()
 		}
 	} else {
 		err = s.buildSelectedList()
@@ -149,7 +156,7 @@ func (s *Selector[T]) buildTable(table TableReference) error {
 			return err
 		}
 	default:
-		return errs.NewErrUnsupportedTable(table)
+		return errs.NewUnsupportedTableReferenceError(table)
 	}
 	return nil
 }
@@ -188,18 +195,8 @@ func (s *Selector[T]) buildGroupBy() error {
 }
 
 func (s *Selector[T]) buildAllColumns() error {
-	if s.table != nil {
-		if _, ok := s.table.(Table); !ok {
-			err := s.buildTableAs(s.table)
-			if err != nil {
-				return err
-			}
-			s.star()
-			return nil
-		}
-	}
 	for i, cMeta := range s.meta.Columns {
-		// it should never return error, we can safely ignore it
+		// 永远不会返回 error
 		_ = s.buildColumns(i, cMeta.FieldName)
 	}
 	return nil
@@ -249,11 +246,9 @@ func (s *Selector[T]) selectAggregate(aggregate Aggregate) error {
 		return errs.NewInvalidFieldError(aggregate.arg)
 	}
 	if aggregate.table != nil {
-		if t, ok := aggregate.table.(Table); ok {
-			if t.alias != "" {
-				s.quote(t.alias)
-				s.point()
-			}
+		if alias := aggregate.table.getAlias(); alias != "" {
+			s.quote(alias)
+			s.point()
 		}
 	}
 	s.quote(cMeta.ColumnName)
@@ -269,11 +264,9 @@ func (s *Selector[T]) selectAggregate(aggregate Aggregate) error {
 
 func (s *Selector[T]) buildColumn(column Column) error {
 	if column.table != nil {
-		if t, ok := column.table.(Table); ok {
-			if t.alias != "" {
-				s.quote(t.alias)
-				s.point()
-			}
+		if alias := column.table.getAlias(); alias != "" {
+			s.quote(alias)
+			s.point()
 		}
 	}
 	cMeta, ok := s.meta.FieldMap[column.name]

--- a/select_test.go
+++ b/select_test.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"testing"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gotomicro/eorm/internal/errs"
 	"github.com/gotomicro/eorm/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRawQuery_Get_baseType(t *testing.T) {
@@ -49,14 +50,14 @@ func TestRawQuery_Get_baseType(t *testing.T) {
 		{
 			name: "res RawQuery int",
 			queryRes: func(t *testing.T) any {
-				queryer := RawQuery[int](db, "SELECT `age` FROM `test_model` LIMIT ?;", 1)
+				queryer := RawQuery[int](db, "SELECT `age` FROM `test_model` AS `t1` LIMIT ?;", 1)
 				result, err := queryer.Get(context.Background())
 				require.NoError(t, err)
 				return result
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10)
-				mock.ExpectQuery("SELECT `age` FROM `test_model` LIMIT ?;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1` LIMIT ?;").
 					WithArgs(1).
 					WillReturnRows(rows)
 			},
@@ -296,7 +297,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res int",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[int](db).Select(C("Age")).From(tm)
 				result, err := queryer.Get(context.Background())
 				require.NoError(t, err)
@@ -304,7 +305,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10)
-				mock.ExpectQuery("SELECT `age` FROM `test_model` LIMIT ?;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1` LIMIT ?;").
 					WithArgs(1).
 					WillReturnRows(rows)
 			},
@@ -316,7 +317,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res int32",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[int32](db).Select(C("Age")).From(tm)
 				result, err := queryer.Get(context.Background())
 				require.NoError(t, err)
@@ -324,7 +325,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10)
-				mock.ExpectQuery("SELECT `age` FROM `test_model` LIMIT ?;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1` LIMIT ?;").
 					WithArgs(1).
 					WillReturnRows(rows)
 			},
@@ -336,7 +337,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res int64",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[int64](db).Select(C("Age")).From(tm)
 				result, err := queryer.Get(context.Background())
 				require.NoError(t, err)
@@ -344,7 +345,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10)
-				mock.ExpectQuery("SELECT `age` FROM `test_model` LIMIT ?;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1` LIMIT ?;").
 					WithArgs(1).
 					WillReturnRows(rows)
 			},
@@ -356,7 +357,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "avg res float32",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[float32](db).Select(C("Age")).From(tm)
 				result, err := queryer.Get(context.Background())
 				require.NoError(t, err)
@@ -364,7 +365,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10.2)
-				mock.ExpectQuery("SELECT `age` FROM `test_model` LIMIT ?;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1` LIMIT ?;").
 					WithArgs(1).
 					WillReturnRows(rows)
 			},
@@ -376,7 +377,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "avg res float64",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[float64](db).Select(C("Age")).From(tm)
 				result, err := queryer.Get(context.Background())
 				require.NoError(t, err)
@@ -384,7 +385,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10.02)
-				mock.ExpectQuery("SELECT `age` FROM `test_model` LIMIT ?;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1` LIMIT ?;").
 					WithArgs(1).
 					WillReturnRows(rows)
 			},
@@ -396,7 +397,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res byte",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[byte](db).Select(C("FirstName")).
 					From(tm).Where(C("Id").EQ(1))
 				result, err := queryer.Get(context.Background())
@@ -405,7 +406,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"first_name"}).AddRow('D')
-				mock.ExpectQuery("SELECT `first_name` FROM `test_model` WHERE `id`=? LIMIT ?;").
+				mock.ExpectQuery("SELECT `first_name` FROM `test_model` AS `t1` WHERE `id`=? LIMIT ?;").
 					WithArgs(1, 1).
 					WillReturnRows(rows)
 			},
@@ -417,7 +418,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res bytes",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[[]byte](db).Select(C("FirstName")).
 					From(tm).Where(C("Id").EQ(1))
 				result, err := queryer.Get(context.Background())
@@ -426,7 +427,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"first_name"}).AddRow([]byte("Li"))
-				mock.ExpectQuery("SELECT `first_name` FROM `test_model` WHERE `id`=? LIMIT ?;").
+				mock.ExpectQuery("SELECT `first_name` FROM `test_model` AS `t1` WHERE `id`=? LIMIT ?;").
 					WithArgs(1, 1).
 					WillReturnRows(rows)
 			},
@@ -438,7 +439,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res string",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[string](db).Select(C("FirstName")).
 					From(tm).Where(C("Id").EQ(1))
 				result, err := queryer.Get(context.Background())
@@ -447,7 +448,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"first_name"}).AddRow("Da")
-				mock.ExpectQuery("SELECT `first_name` FROM `test_model` WHERE `id`=? LIMIT ?;").
+				mock.ExpectQuery("SELECT `first_name` FROM `test_model` AS `t1` WHERE `id`=? LIMIT ?;").
 					WithArgs(1, 1).
 					WillReturnRows(rows)
 			},
@@ -459,7 +460,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res struct ptr",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[TestModel](db).Select(C("FirstName"), C("Age")).From(TableOf(&TestModel{})).
+				queryer := NewSelector[TestModel](db).Select(C("FirstName"), C("Age")).
 					Where(C("Id").EQ(1))
 				result, err := queryer.Get(context.Background())
 				require.NoError(t, err)
@@ -481,7 +482,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 		{
 			name: "res sql.NullString",
 			queryRes: func(t *testing.T) any {
-				tm := TableOf(&TestModel{})
+				tm := TableOf(&TestModel{}, "t1")
 				queryer := NewSelector[sql.NullString](db).Select(C("LastName")).
 					From(tm).Where(C("Id").EQ(1))
 				result, err := queryer.Get(context.Background())
@@ -490,7 +491,7 @@ func TestSelector_Get_baseType(t *testing.T) {
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"last_name"}).AddRow([]byte("ming"))
-				mock.ExpectQuery("SELECT `last_name` FROM `test_model` WHERE `id`=? LIMIT ?;").
+				mock.ExpectQuery("SELECT `last_name` FROM `test_model` AS `t1` WHERE `id`=? LIMIT ?;").
 					WithArgs(1, 1).
 					WillReturnRows(rows)
 			},
@@ -532,7 +533,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "res int",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[int](db).Select(C("Age")).From(TableOf(&TestModel{}))
+				queryer := NewSelector[int](db).Select(C("Age")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
@@ -540,7 +541,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10).
 					AddRow(18).AddRow(22)
-				mock.ExpectQuery("SELECT `age` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*int) {
@@ -554,7 +555,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "res int32",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[int32](db).Select(C("Age")).From(TableOf(&TestModel{}))
+				queryer := NewSelector[int32](db).Select(C("Age")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
@@ -562,7 +563,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10).
 					AddRow(18).AddRow(22)
-				mock.ExpectQuery("SELECT `age` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*int32) {
@@ -576,7 +577,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "avg res int64",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[int64](db).Select(C("Age")).From(TableOf(&TestModel{}))
+				queryer := NewSelector[int64](db).Select(C("Age")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
@@ -584,7 +585,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10).
 					AddRow(18).AddRow(22)
-				mock.ExpectQuery("SELECT `age` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*int64) {
@@ -598,14 +599,14 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "avg res float32",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[float32](db).Select(C("Age")).From(TableOf(&TestModel{}))
+				queryer := NewSelector[float32](db).Select(C("Age")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10.2).AddRow(18.8)
-				mock.ExpectQuery("SELECT `age` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*float32) {
@@ -619,14 +620,14 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "avg res float64",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[float64](db).Select(C("Age")).From(TableOf(&TestModel{}))
+				queryer := NewSelector[float64](db).Select(C("Age")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"age"}).AddRow(10.2).AddRow(18.8)
-				mock.ExpectQuery("SELECT `age` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `age` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*float64) {
@@ -640,15 +641,14 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "res byte",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[byte](db).Select(C("FirstName")).
-					From(TableOf(&TestModel{}))
+				queryer := NewSelector[byte](db).Select(C("FirstName")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"first_name"}).AddRow('D').AddRow('a')
-				mock.ExpectQuery("SELECT `first_name` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `first_name` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*byte) {
@@ -662,15 +662,14 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "res bytes",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[[]byte](db).Select(C("FirstName")).
-					From(TableOf(&TestModel{}))
+				queryer := NewSelector[[]byte](db).Select(C("FirstName")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"first_name"}).AddRow([]byte("Li")).AddRow([]byte("Liu"))
-				mock.ExpectQuery("SELECT `first_name` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `first_name` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*[]byte) {
@@ -684,15 +683,14 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "res string",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[string](db).Select(C("FirstName")).
-					From(TableOf(&TestModel{}))
+				queryer := NewSelector[string](db).Select(C("FirstName")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
 			},
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"first_name"}).AddRow("Da").AddRow("Li")
-				mock.ExpectQuery("SELECT `first_name` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `first_name` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: func() (res []*string) {
@@ -706,8 +704,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "res struct ptr",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[TestModel](db).Select(C("FirstName"), C("Age")).
-					From(TableOf(&TestModel{}))
+				queryer := NewSelector[TestModel](db).Select(C("FirstName"), C("Age")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
@@ -715,7 +712,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"first_name", "age"}).
 					AddRow("Da", 18).AddRow("Xiao", 16)
-				mock.ExpectQuery("SELECT `first_name`,`age` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `first_name`,`age` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: []*TestModel{
@@ -732,8 +729,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 		{
 			name: "res sql.NullString",
 			queryRes: func(t *testing.T) any {
-				queryer := NewSelector[sql.NullString](db).Select(C("LastName")).
-					From(TableOf(&TestModel{}))
+				queryer := NewSelector[sql.NullString](db).Select(C("LastName")).From(TableOf(&TestModel{}, "t1"))
 				result, err := queryer.GetMulti(context.Background())
 				require.NoError(t, err)
 				return result
@@ -741,7 +737,7 @@ func TestSelector_GetMulti_baseType(t *testing.T) {
 			mockOrder: func(mock sqlmock.Sqlmock) {
 				rows := mock.NewRows([]string{"last_name"}).
 					AddRow([]byte("ming")).AddRow([]byte("gang"))
-				mock.ExpectQuery("SELECT `last_name` FROM `test_model`;").
+				mock.ExpectQuery("SELECT `last_name` FROM `test_model` AS `t1`;").
 					WillReturnRows(rows)
 			},
 			wantVal: []*sql.NullString{
@@ -771,232 +767,232 @@ func TestSelectable(t *testing.T) {
 	testCases := []CommonTestCase{
 		{
 			name:    "simple",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db),
 			wantSql: "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model`;",
 		},
 		{
 			name:    "columns",
-			builder: NewSelector[TestModel](db).Select(Columns("Id", "FirstName")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Columns("Id", "FirstName")),
 			wantSql: "SELECT `id`,`first_name` FROM `test_model`;",
 		},
 		{
 			name:    "alias",
-			builder: NewSelector[TestModel](db).Select(Columns("Id"), C("FirstName").As("name")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Columns("Id"), C("FirstName").As("name")),
 			wantSql: "SELECT `id`,`first_name` AS `name` FROM `test_model`;",
 		},
 		{
 			name:    "aggregate",
-			builder: NewSelector[TestModel](db).Select(Columns("Id"), Avg("Age").As("avg_age")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Columns("Id"), Avg("Age").As("avg_age")),
 			wantSql: "SELECT `id`,AVG(`age`) AS `avg_age` FROM `test_model`;",
 		},
 		{
 			name:    "raw",
-			builder: NewSelector[TestModel](db).Select(Columns("Id"), Raw("AVG(DISTINCT `age`)")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Columns("Id"), Raw("AVG(DISTINCT `age`)")),
 			wantSql: "SELECT `id`,AVG(DISTINCT `age`) FROM `test_model`;",
 		},
 		{
 			name:    "invalid columns",
-			builder: NewSelector[TestModel](db).Select(Columns("Invalid"), Raw("AVG(DISTINCT `age`)")).From(TableOf(&TestModel{})),
+			builder: NewSelector[TestModel](db).Select(Columns("Invalid"), Raw("AVG(DISTINCT `age`)")),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 		{
 			name:    "order by",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Age"), DESC("Id")),
+			builder: NewSelector[TestModel](db).OrderBy(ASC("Age"), DESC("Id")),
 			wantSql: "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` ORDER BY `age` ASC,`id` DESC;",
 		},
 		{
 			name:    "order by invalid column",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Invalid"), DESC("Id")),
+			builder: NewSelector[TestModel](db).OrderBy(ASC("Invalid"), DESC("Id")),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 		{
 			name:    "group by",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).GroupBy("Age", "Id"),
+			builder: NewSelector[TestModel](db).GroupBy("Age", "Id"),
 			wantSql: "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `age`,`id`;",
 		},
 		{
 			name:    "group by invalid column",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).GroupBy("Invalid", "Id"),
+			builder: NewSelector[TestModel](db).GroupBy("Invalid", "Id"),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 		{
 			name:     "offset",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Age"), DESC("Id")).Offset(10),
+			builder:  NewSelector[TestModel](db).OrderBy(ASC("Age"), DESC("Id")).Offset(10),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` ORDER BY `age` ASC,`id` DESC OFFSET ?;",
 			wantArgs: []interface{}{10},
 		},
 		{
 			name:     "limit",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Age"), DESC("Id")).Offset(10).Limit(100),
+			builder:  NewSelector[TestModel](db).OrderBy(ASC("Age"), DESC("Id")).Offset(10).Limit(100),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` ORDER BY `age` ASC,`id` DESC OFFSET ? LIMIT ?;",
 			wantArgs: []interface{}{10, 100},
 		},
 		{
 			name:     "where",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("Id").EQ(10)),
+			builder:  NewSelector[TestModel](db).Where(C("Id").EQ(10)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `id`=?;",
 			wantArgs: []interface{}{10},
 		},
 		{
 			name:    "no where",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(),
+			builder: NewSelector[TestModel](db).Where(),
 			wantSql: "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model`;",
 		},
 		{
 			name:     "having",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(Avg("Age").EQ(18)),
+			builder:  NewSelector[TestModel](db).GroupBy("FirstName").Having(Avg("Age").EQ(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING AVG(`age`)=?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:    "no having",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(),
+			builder: NewSelector[TestModel](db).GroupBy("FirstName").Having(),
 			wantSql: "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name`;",
 		},
 		{
 			name:     "alias in having",
-			builder:  NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(C("avg_age").LT(20)),
+			builder:  NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).GroupBy("FirstName").Having(C("avg_age").LT(20)),
 			wantSql:  "SELECT `id`,`first_name`,AVG(`age`) AS `avg_age` FROM `test_model` GROUP BY `first_name` HAVING `avg_age`<?;",
 			wantArgs: []interface{}{20},
 		},
 		{
 			name:    "invalid alias in having",
-			builder: NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(C("Invalid").LT(20)),
+			builder: NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).GroupBy("FirstName").Having(C("Invalid").LT(20)),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 		{
 			name:     "in",
-			builder:  NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").In(1, 2, 3)),
+			builder:  NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").In(1, 2, 3)),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE `id` IN (?,?,?);",
 			wantArgs: []interface{}{1, 2, 3},
 		},
 		{
 			name:     "not in",
-			builder:  NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").NotIn(1, 2, 3)),
+			builder:  NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").NotIn(1, 2, 3)),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE `id` NOT IN (?,?,?);",
 			wantArgs: []interface{}{1, 2, 3},
 		},
 		{
 			// 传入的参数为切片
 			name:     "slice in",
-			builder:  NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").In([]int{1, 2, 3})),
+			builder:  NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").In([]int{1, 2, 3})),
 			wantSql:  "SELECT `id` FROM `test_model` WHERE `id` IN (?);",
 			wantArgs: []interface{}{[]int{1, 2, 3}},
 		},
 		{
 			// in 后面没有值
 			name:    "no in",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").In()),
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").In()),
 			wantSql: "SELECT `id` FROM `test_model` WHERE FALSE;",
 		},
 		{
 			// Notin 后面没有值
 			name:    "no in",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").NotIn()),
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").NotIn()),
 			wantSql: "SELECT `id` FROM `test_model` WHERE FALSE;",
 		},
 		{
 			name:    "in empty slice",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").In([]any{}...)),
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").In([]any{}...)),
 			wantSql: "SELECT `id` FROM `test_model` WHERE FALSE;",
 		},
 		{
 			name:    "NOT In empty slice",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").NotIn([]any{}...)),
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").NotIn([]any{}...)),
 			wantSql: "SELECT `id` FROM `test_model` WHERE FALSE;",
 		},
 		// 模糊查询
 		{
 			name:    "NOT In empty slice",
-			builder: NewSelector[TestModel](db).Select(Columns("Id")).From(TableOf(&TestModel{})).Where(C("Id").NotIn([]any{}...)),
+			builder: NewSelector[TestModel](db).Select(Columns("Id")).Where(C("Id").NotIn([]any{}...)),
 			wantSql: "SELECT `id` FROM `test_model` WHERE FALSE;",
 		},
 		{
 			name:     "where not like %",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").NotLike("%ming")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").NotLike("%ming")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` NOT LIKE ?;",
 			wantArgs: []interface{}{"%ming"},
 		},
 		{
 			name:     "where like %",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").Like("zhang%")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").Like("zhang%")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` LIKE ?;",
 			wantArgs: []interface{}{"zhang%"},
 		},
 		{
 			name:     "where not like _",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").NotLike("_三_")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").NotLike("_三_")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` NOT LIKE ?;",
 			wantArgs: []interface{}{"_三_"},
 		},
 		{
 			name:     "where like _",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").Like("_三_")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").Like("_三_")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` LIKE ?;",
 			wantArgs: []interface{}{"_三_"},
 		},
 		{
 			name:     "where not like []",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").NotLike("老[1-9]")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").NotLike("老[1-9]")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` NOT LIKE ?;",
 			wantArgs: []interface{}{"老[1-9]"},
 		},
 		{
 			name:     "where like []",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").Like("老[1-9]")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").Like("老[1-9]")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` LIKE ?;",
 			wantArgs: []interface{}{"老[1-9]"},
 		},
 		{
 			name:     "where not like [^ ]",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").NotLike("老[^1-4]")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").NotLike("老[^1-4]")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` NOT LIKE ?;",
 			wantArgs: []interface{}{"老[^1-4]"},
 		},
 		{
 			name:     "where like [^ ]",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("FirstName").Like("老[^1-4]")),
+			builder:  NewSelector[TestModel](db).Where(C("FirstName").Like("老[^1-4]")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `first_name` LIKE ?;",
 			wantArgs: []interface{}{"老[^1-4]"},
 		},
 
 		{
 			name:     "where not like int",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("Age").NotLike(18)),
+			builder:  NewSelector[TestModel](db).Where(C("Age").NotLike(18)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `age` NOT LIKE ?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:     "where like int",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Where(C("Age").Like(22)),
+			builder:  NewSelector[TestModel](db).Where(C("Age").Like(22)),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` WHERE `age` LIKE ?;",
 			wantArgs: []interface{}{22},
 		},
 		{
 			name:     "having like %",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(C("LastName").Like("%li")),
+			builder:  NewSelector[TestModel](db).GroupBy("FirstName").Having(C("LastName").Like("%li")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING `last_name` LIKE ?;",
 			wantArgs: []interface{}{"%li"},
 		},
 		{
 			name:     "having no like %",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(C("LastName").NotLike("%yy%")),
+			builder:  NewSelector[TestModel](db).GroupBy("FirstName").Having(C("LastName").NotLike("%yy%")),
 			wantSql:  "SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` GROUP BY `first_name` HAVING `last_name` NOT LIKE ?;",
 			wantArgs: []interface{}{"%yy%"},
 		},
 		{
 			name:    "distinct single row",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Distinct().Select(C("FirstName")),
+			builder: NewSelector[TestModel](db).Distinct().Select(C("FirstName")),
 			wantSql: "SELECT DISTINCT `first_name` FROM `test_model`;",
 		},
 		{
 			name:    "count distinct",
-			builder: NewSelector[TestModel](db).From(TableOf(&TestModel{})).Select(CountDistinct("FirstName")),
+			builder: NewSelector[TestModel](db).Select(CountDistinct("FirstName")),
 			wantSql: "SELECT COUNT(DISTINCT `first_name`) FROM `test_model`;",
 		},
 		{
 			name:     "having count distinct",
-			builder:  NewSelector[TestModel](db).From(TableOf(&TestModel{})).Select(C("FirstName")).GroupBy("FirstName").Having(CountDistinct("FirstName").EQ("jack")),
+			builder:  NewSelector[TestModel](db).Select(C("FirstName")).GroupBy("FirstName").Having(CountDistinct("FirstName").EQ("jack")),
 			wantSql:  "SELECT `first_name` FROM `test_model` GROUP BY `first_name` HAVING COUNT(DISTINCT `first_name`)=?;",
 			wantArgs: []interface{}{"jack"},
 		},
@@ -1021,97 +1017,97 @@ func TestSelectableCombination(t *testing.T) {
 	testCases := []CommonTestCase{
 		{
 			name:    "simple",
-			builder: NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})),
+			builder: NewSelector[TestCombinedModel](db),
 			wantSql: "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model`;",
 		},
 		{
 			name:    "columns",
-			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id", "FirstName", "CreateTime")).From(TableOf(&TestCombinedModel{})),
+			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id", "FirstName", "CreateTime")),
 			wantSql: "SELECT `id`,`first_name`,`create_time` FROM `test_combined_model`;",
 		},
 		{
 			name:    "alias",
-			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), C("CreateTime").As("creation")).From(TableOf(&TestCombinedModel{})),
+			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), C("CreateTime").As("creation")),
 			wantSql: "SELECT `id`,`create_time` AS `creation` FROM `test_combined_model`;",
 		},
 		{
 			name:    "aggregate",
-			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), Max("CreateTime").As("max_time")).From(TableOf(&TestCombinedModel{})),
+			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), Max("CreateTime").As("max_time")),
 			wantSql: "SELECT `id`,MAX(`create_time`) AS `max_time` FROM `test_combined_model`;",
 		},
 		{
 			name:    "raw",
-			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), Raw("AVG(DISTINCT `create_time`)")).From(TableOf(&TestCombinedModel{})),
+			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), Raw("AVG(DISTINCT `create_time`)")),
 			wantSql: "SELECT `id`,AVG(DISTINCT `create_time`) FROM `test_combined_model`;",
 		},
 		{
 			name:    "invalid columns",
-			builder: NewSelector[TestCombinedModel](db).Select(Columns("Invalid"), Raw("AVG(DISTINCT `age`)")).From(TableOf(&TestCombinedModel{})),
+			builder: NewSelector[TestCombinedModel](db).Select(Columns("Invalid"), Raw("AVG(DISTINCT `age`)")),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 		{
 			name:    "order by",
-			builder: NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).OrderBy(ASC("Age"), DESC("CreateTime")),
+			builder: NewSelector[TestCombinedModel](db).OrderBy(ASC("Age"), DESC("CreateTime")),
 			wantSql: "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model` ORDER BY `age` ASC,`create_time` DESC;",
 		},
 		{
 			name:    "order by invalid column",
-			builder: NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).OrderBy(ASC("Invalid"), DESC("Id")),
+			builder: NewSelector[TestCombinedModel](db).OrderBy(ASC("Invalid"), DESC("Id")),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 		{
 			name:    "group by",
-			builder: NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).GroupBy("CreateTime", "Id"),
+			builder: NewSelector[TestCombinedModel](db).GroupBy("CreateTime", "Id"),
 			wantSql: "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model` GROUP BY `create_time`,`id`;",
 		},
 		{
 			name:    "group by invalid column",
-			builder: NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).GroupBy("Invalid", "Id"),
+			builder: NewSelector[TestCombinedModel](db).GroupBy("Invalid", "Id"),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 		{
 			name:     "offset",
-			builder:  NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).OrderBy(ASC("Age"), DESC("CreateTime")).Offset(10),
+			builder:  NewSelector[TestCombinedModel](db).OrderBy(ASC("Age"), DESC("CreateTime")).Offset(10),
 			wantSql:  "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model` ORDER BY `age` ASC,`create_time` DESC OFFSET ?;",
 			wantArgs: []interface{}{10},
 		},
 		{
 			name:     "limit",
-			builder:  NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).OrderBy(ASC("Age"), DESC("CreateTime")).Offset(10).Limit(100),
+			builder:  NewSelector[TestCombinedModel](db).OrderBy(ASC("Age"), DESC("CreateTime")).Offset(10).Limit(100),
 			wantSql:  "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model` ORDER BY `age` ASC,`create_time` DESC OFFSET ? LIMIT ?;",
 			wantArgs: []interface{}{10, 100},
 		},
 		{
 			name:     "where",
-			builder:  NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).Where(C("Id").EQ(10).And(C("CreateTime").EQ(10))),
+			builder:  NewSelector[TestCombinedModel](db).Where(C("Id").EQ(10).And(C("CreateTime").EQ(10))),
 			wantSql:  "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model` WHERE (`id`=?) AND (`create_time`=?);",
 			wantArgs: []interface{}{10, 10},
 		},
 		{
 			name:    "no where",
-			builder: NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).Where(),
+			builder: NewSelector[TestCombinedModel](db).Where(),
 			wantSql: "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model`;",
 		},
 		{
 			name:     "having",
-			builder:  NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).GroupBy("FirstName").Having(Max("CreateTime").EQ(18)),
+			builder:  NewSelector[TestCombinedModel](db).GroupBy("FirstName").Having(Max("CreateTime").EQ(18)),
 			wantSql:  "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model` GROUP BY `first_name` HAVING MAX(`create_time`)=?;",
 			wantArgs: []interface{}{18},
 		},
 		{
 			name:    "no having",
-			builder: NewSelector[TestCombinedModel](db).From(TableOf(&TestCombinedModel{})).GroupBy("CreateTime").Having(),
+			builder: NewSelector[TestCombinedModel](db).GroupBy("CreateTime").Having(),
 			wantSql: "SELECT `create_time`,`update_time`,`id`,`first_name`,`age`,`last_name` FROM `test_combined_model` GROUP BY `create_time`;",
 		},
 		{
 			name:     "alias in having",
-			builder:  NewSelector[TestCombinedModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("CreateTime").As("create")).From(TableOf(&TestCombinedModel{})).GroupBy("FirstName").Having(C("create").LT(20)),
+			builder:  NewSelector[TestCombinedModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("CreateTime").As("create")).GroupBy("FirstName").Having(C("create").LT(20)),
 			wantSql:  "SELECT `id`,`first_name`,AVG(`create_time`) AS `create` FROM `test_combined_model` GROUP BY `first_name` HAVING `create`<?;",
 			wantArgs: []interface{}{20},
 		},
 		{
 			name:    "invalid alias in having",
-			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).From(TableOf(&TestCombinedModel{})).GroupBy("FirstName").Having(C("Invalid").LT(20)),
+			builder: NewSelector[TestCombinedModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).GroupBy("FirstName").Having(C("Invalid").LT(20)),
 			wantErr: errs.NewInvalidFieldError("Invalid"),
 		},
 	}
@@ -1145,13 +1141,13 @@ type TestCombinedModel struct {
 
 func ExampleSelector_OrderBy() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Age")).Build()
+	query, _ := NewSelector[TestModel](db).OrderBy(ASC("Age")).Build()
 	fmt.Printf("case1\n%s", query.string())
-	query, _ = NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Age", "Id")).Build()
+	query, _ = NewSelector[TestModel](db).OrderBy(ASC("Age", "Id")).Build()
 	fmt.Printf("case2\n%s", query.string())
-	query, _ = NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Age"), ASC("Id")).Build()
+	query, _ = NewSelector[TestModel](db).OrderBy(ASC("Age"), ASC("Id")).Build()
 	fmt.Printf("case3\n%s", query.string())
-	query, _ = NewSelector[TestModel](db).From(TableOf(&TestModel{})).OrderBy(ASC("Age"), DESC("Id")).Build()
+	query, _ = NewSelector[TestModel](db).OrderBy(ASC("Age"), DESC("Id")).Build()
 	fmt.Printf("case4\n%s", query.string())
 	// Output:
 	// case1
@@ -1170,9 +1166,9 @@ func ExampleSelector_OrderBy() {
 
 func ExampleSelector_Having() {
 	db := memoryDB()
-	query, _ := NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(C("avg_age").LT(20)).Build()
+	query, _ := NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).GroupBy("FirstName").Having(C("avg_age").LT(20)).Build()
 	fmt.Printf("case1\n%s", query.string())
-	query, err := NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).From(TableOf(&TestModel{})).GroupBy("FirstName").Having(C("Invalid").LT(20)).Build()
+	query, err := NewSelector[TestModel](db).Select(Columns("Id"), Columns("FirstName"), Avg("Age").As("avg_age")).GroupBy("FirstName").Having(C("Invalid").LT(20)).Build()
 	fmt.Printf("case2\n%s", err)
 	// Output:
 	// case1
@@ -1184,7 +1180,7 @@ func ExampleSelector_Having() {
 
 func ExampleSelector_Select() {
 	db := memoryDB()
-	tm := TableOf(&TestModel{})
+	tm := TableOf(&TestModel{}, "t1")
 	cases := []*Selector[TestModel]{
 		// case0: all columns are included
 		NewSelector[TestModel](db).From(tm),
@@ -1204,32 +1200,31 @@ func ExampleSelector_Select() {
 	}
 	// Output:
 	// case0:
-	// SQL: SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model`;
+	// SQL: SELECT `id`,`first_name`,`age`,`last_name` FROM `test_model` AS `t1`;
 	// Args: []interface {}(nil)
 	// case1:
-	// SQL: SELECT `id`,`age` FROM `test_model`;
+	// SQL: SELECT `id`,`age` FROM `test_model` AS `t1`;
 	// Args: []interface {}(nil)
 	// case2:
-	// SQL: SELECT `id` AS `my_id` FROM `test_model`;
+	// SQL: SELECT `id` AS `my_id` FROM `test_model` AS `t1`;
 	// Args: []interface {}(nil)
 	// case3:
-	// SQL: SELECT AVG(`age`) AS `avg_age` FROM `test_model`;
+	// SQL: SELECT AVG(`age`) AS `avg_age` FROM `test_model` AS `t1`;
 	// Args: []interface {}(nil)
 	// case4:
-	// SQL: SELECT COUNT(DISTINCT `age`) AS `age_cnt` FROM `test_model`;
+	// SQL: SELECT COUNT(DISTINCT `age`) AS `age_cnt` FROM `test_model` AS `t1`;
 	// Args: []interface {}(nil)
 }
 
 func ExampleSelector_Distinct() {
 	db := memoryDB()
-	tm := TableOf(&TestModel{})
 	cases := []*Selector[TestModel]{
 		// case0: disinct column
-		NewSelector[TestModel](db).From(tm).Distinct().Select(C("FirstName")),
+		NewSelector[TestModel](db).Distinct().Select(C("FirstName")),
 		// case1: aggregation function using distinct
-		NewSelector[TestModel](db).From(tm).Select(CountDistinct("FirstName")),
+		NewSelector[TestModel](db).Select(CountDistinct("FirstName")),
 		// case2: having using distinct
-		NewSelector[TestModel](db).From(tm).Select(C("FirstName")).GroupBy("FirstName").Having(CountDistinct("FirstName").EQ("jack")),
+		NewSelector[TestModel](db).Select(C("FirstName")).GroupBy("FirstName").Having(CountDistinct("FirstName").EQ("jack")),
 	}
 
 	for index, tc := range cases {
@@ -1275,7 +1270,14 @@ func TestSelector_Join(t *testing.T) {
 	}{
 		{
 			name: "specify table",
-			s:    NewSelector[Order](db).From(TableOf(&OrderDetail{})),
+			s:    NewSelector[Order](db).From(TableOf(&OrderDetail{}, "t1")),
+			wantQuery: &Query{
+				SQL: "SELECT `order_id`,`item_id`,`using_col1`,`using_col2` FROM `order_detail` AS `t1`;",
+			},
+		},
+		{
+			name: "specify table with empty alias",
+			s:    NewSelector[Order](db).From(TableOf(&OrderDetail{}, "")),
 			wantQuery: &Query{
 				SQL: "SELECT `order_id`,`item_id`,`using_col1`,`using_col2` FROM `order_detail`;",
 			},
@@ -1288,79 +1290,34 @@ func TestSelector_Join(t *testing.T) {
 			},
 		},
 		{
-			name: "no from no As",
+			name: "join-using",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{})
-				t2 := TableOf(&OrderDetail{})
-				return NewSelector[Order](db).Select(t1.C("UsingCol1"), t2.C("UsingCol1"))
-			}(),
-			wantQuery: &Query{
-				SQL: "SELECT `using_col1`,`using_col1` FROM `order`;",
-			},
-		},
-		{
-			name: "no from one As",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{})
-				return NewSelector[Order](db).Select(t1.C("UsingCol1"), t2.C("UsingCol1"))
-			}(),
-			wantQuery: &Query{
-				SQL: "SELECT `t1`.`using_col1`,`using_col1` FROM `order`;",
-			},
-		},
-		{
-			name: "no from all As",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
-				return NewSelector[Order](db).Select(t1.C("UsingCol1"), t2.C("UsingCol1"))
-			}(),
-			wantQuery: &Query{
-				SQL: "SELECT `t1`.`using_col1`,`t2`.`using_col1` FROM `order`;",
-			},
-		},
-		{
-			name: "join-using no As",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{})
-				t2 := TableOf(&OrderDetail{})
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3)
+				return NewSelector[Order](db).Select(Raw("*")).From(t3)
 			}(),
 			wantQuery: &Query{
-				SQL: "SELECT * FROM (`order` JOIN `order_detail` USING (`using_col1`,`using_col2`));",
-			},
-		},
-		{
-			name: "join-using As",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
-				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3)
-			}(),
-			wantQuery: &Query{
-				SQL: "SELECT `t1`.* FROM (`order` AS `t1` JOIN `order_detail` AS `t2` USING (`using_col1`,`using_col2`));",
+				SQL: "SELECT * FROM (`order` AS `t1` JOIN `order_detail` AS `t2` USING (`using_col1`,`using_col2`));",
 			},
 		},
 		{
 			name: "join-using-cols",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{})
-				t2 := TableOf(&OrderDetail{})
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
 				return NewSelector[Order](db).From(t3).Select(t1.C("UsingCol1"), t2.C("UsingCol1"))
 			}(),
 			wantQuery: &Query{
-				SQL: "SELECT `using_col1`,`using_col1` FROM (`order` JOIN `order_detail` USING (`using_col1`,`using_col2`));",
+				SQL: "SELECT `t1`.`using_col1`,`t2`.`using_col1` FROM (`order` AS `t1` JOIN `order_detail` AS `t2` USING (`using_col1`,`using_col2`));",
 			},
 		},
 		{
 			name: "join-using-cols-invalid",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{})
-				t2 := TableOf(&OrderDetail{})
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("invalid", "invalid2")
 				return NewSelector[Order](db).From(t3).Select(t1.C("UsingCol2"))
 			}(),
@@ -1369,94 +1326,45 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "join-using-cols-Avg",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{})
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3).Select(t1.Avg("UsingCol1").As("UsingCol1"))
+				return NewSelector[Order](db).From(t3).Select(t1.Avg("UsingCol1").As("avg_using_col1"))
 			}(),
 			wantQuery: &Query{
-				SQL: "SELECT AVG(`t1`.`using_col1`) AS `UsingCol1` FROM (`order` AS `t1` JOIN `order_detail` USING (`using_col1`,`using_col2`));",
-			},
-		},
-		{
-			name: "join-using-cols-all empty As ",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{})
-				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3).Select(t1.AllColumns(), t2.AllColumns())
-			}(),
-			wantQuery: &Query{
-				SQL: "SELECT `t1`.*,``.* FROM (`order` AS `t1` JOIN `order_detail` USING (`using_col1`,`using_col2`));",
+				SQL: "SELECT AVG(`t1`.`using_col1`) AS `avg_using_col1` FROM (`order` AS `t1` JOIN `order_detail` AS `t2` USING (`using_col1`,`using_col2`));",
 			},
 		},
 		{
 			name: "join-using-Avg-invalid",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{})
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
 				return NewSelector[Order](db).From(t3).Select(t1.Avg("invalid"))
 			}(),
 			wantErr: errs.NewInvalidFieldError("invalid"),
 		},
 		{
-			name: "join-using-where no As",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{})
-				t2 := TableOf(&OrderDetail{})
-				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3).Where(C("UsingCol1").EQ(10).And(C("UsingCol2").EQ(10)))
-			}(),
-			wantQuery: &Query{
-				SQL:  "SELECT * FROM (`order` JOIN `order_detail` USING (`using_col1`,`using_col2`)) WHERE (`using_col1`=?) AND (`using_col2`=?);",
-				Args: []interface{}{10, 10},
-			},
-		},
-		{
 			name: "join-using-where As",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{})
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3).Where(C("UsingCol1").EQ(10).And(C("UsingCol2").EQ(10)))
+				return NewSelector[Order](db).Select(t1.AllColumns()).From(t3).Where(C("UsingCol1").EQ(10).And(C("UsingCol2").EQ(10)))
 			}(),
 			wantQuery: &Query{
-				SQL:  "SELECT `t1`.* FROM (`order` AS `t1` JOIN `order_detail` USING (`using_col1`,`using_col2`)) WHERE (`using_col1`=?) AND (`using_col2`=?);",
+				SQL:  "SELECT `t1`.* FROM (`order` AS `t1` JOIN `order_detail` AS `t2` USING (`using_col1`,`using_col2`)) WHERE (`using_col1`=?) AND (`using_col2`=?);",
 				Args: []interface{}{10, 10},
-			},
-		},
-		{
-			name: "left join no As",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{})
-				t2 := TableOf(&OrderDetail{})
-				t3 := t1.LeftJoin(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3)
-			}(),
-			wantQuery: &Query{
-				SQL: "SELECT * FROM (`order` LEFT JOIN `order_detail` USING (`using_col1`,`using_col2`));",
-			},
-		},
-		{
-			name: "right join no As",
-			s: func() QueryBuilder {
-				t1 := TableOf(&Order{})
-				t2 := TableOf(&OrderDetail{})
-				t3 := t1.RightJoin(t2).Using("UsingCol1", "UsingCol2")
-				return NewSelector[Order](db).From(t3)
-			}(),
-			wantQuery: &Query{
-				SQL: "SELECT * FROM (`order` RIGHT JOIN `order_detail` USING (`using_col1`,`using_col2`));",
 			},
 		},
 		{
 			name: "join-on",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				return NewSelector[Order](db).From(t3)
+				return NewSelector[Order](db).Select(t1.AllColumns()).From(t3)
 			}(),
 			wantQuery: &Query{
 				SQL: "SELECT `t1`.* FROM (`order` AS `t1` JOIN `order_detail` AS `t2` ON `t1`.`id`=`t2`.`order_id`);",
@@ -1465,10 +1373,10 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "join-on-where As",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				return NewSelector[Order](db).From(t3).Where(C("UsingCol1").EQ(10).And(C("UsingCol2").EQ(10)))
+				return NewSelector[Order](db).Select(t1.AllColumns()).From(t3).Where(C("UsingCol1").EQ(10).And(C("UsingCol2").EQ(10)))
 			}(),
 			wantQuery: &Query{
 				SQL:  "SELECT `t1`.* FROM (`order` AS `t1` JOIN `order_detail` AS `t2` ON `t1`.`id`=`t2`.`order_id`) WHERE (`using_col1`=?) AND (`using_col2`=?);",
@@ -1478,8 +1386,8 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "join-on-where-invalid-clos",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return NewSelector[Order](db).From(t3).Select(t1.C("invalid")).Where(C("invalid").EQ(10).And(C("UsingCol2").EQ(10)))
 			}(),
@@ -1488,8 +1396,8 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "join-on-where-invalid-Min-clos",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return NewSelector[Order](db).From(t3).Select(t1.Min("invalid"), t1.C("invalid")).Where(C("invalid").EQ(10).And(C("UsingCol2").EQ(10)))
 			}(),
@@ -1499,8 +1407,8 @@ func TestSelector_Join(t *testing.T) {
 			// SELECT MAX(t1.xxx), t2.xxx
 			name: "join-on-where-Max-clos",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.LeftJoin(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return NewSelector[Order](db).From(t3).Select(t1.Max("UsingCol1").As("UsingCol1"), t1.C("UsingCol2")).Where(t1.C("UsingCol2").EQ("UsingCol2_1").And(t1.C("UsingCol2").EQ("UsingCol2_2")))
 			}(),
@@ -1511,12 +1419,12 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "join table",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t3.Join(t4).On(t2.C("ItemId").EQ(t4.C("Id")))
-				return NewSelector[Order](db).From(t5)
+				return NewSelector[Order](db).Select(t1.AllColumns()).From(t5)
 			}(),
 			wantQuery: &Query{
 				SQL: "SELECT `t1`.* FROM " +
@@ -1527,12 +1435,12 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "join table-right",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t3.RightJoin(t4).On(t2.C("ItemId").EQ(t4.C("Id")))
-				return NewSelector[Order](db).From(t5)
+				return NewSelector[Order](db).Select(t1.AllColumns()).From(t5)
 			}(),
 			wantQuery: &Query{
 				SQL: "SELECT `t1`.* FROM ((`order` AS `t1` JOIN `order_detail` AS `t2` ON `t1`.`id`=`t2`.`order_id`) RIGHT JOIN `item` AS `t4` ON `t2`.`item_id`=`t4`.`id`);",
@@ -1541,12 +1449,12 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "join table-left",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t3.LeftJoin(t4).On(t2.C("ItemId").EQ(t4.C("Id")))
-				return NewSelector[Order](db).From(t5)
+				return NewSelector[Order](db).Select(t1.AllColumns()).From(t5)
 			}(),
 			wantQuery: &Query{
 				SQL: "SELECT `t1`.* FROM ((`order` AS `t1` JOIN `order_detail` AS `t2` ON `t1`.`id`=`t2`.`order_id`) LEFT JOIN `item` AS `t4` ON `t2`.`item_id`=`t4`.`id`);",
@@ -1556,10 +1464,10 @@ func TestSelector_Join(t *testing.T) {
 			// SELECT AVG(t1.xxx), AVG(t2.xxx)
 			name: "join table AVG-AVG ",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t3.Join(t4).On(t2.C("ItemId").EQ(t4.C("Id")))
 				return NewSelector[Order](db).From(t5).Select(t1.Avg("UsingCol1").As("UsingCol1"), t1.Avg("UsingCol2").As("UsingCol2"))
 			}(),
@@ -1571,10 +1479,10 @@ func TestSelector_Join(t *testing.T) {
 			// SELECT AVG(t1.xxx), AVG(t2.xxx)
 			name: "join table AVG-AVG invalid ",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t3.Join(t4).On(t2.C("ItemId").EQ(t4.C("Id")))
 				return NewSelector[Order](db).From(t5).Select(t1.Avg("invalid"), t1.Avg("invalid"))
 			}(),
@@ -1584,10 +1492,10 @@ func TestSelector_Join(t *testing.T) {
 			// SELECT t1.xxx, t2.xxx
 			name: "join table C-C ",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t3.Join(t4).On(t2.C("ItemId").EQ(t4.C("Id")))
 				return NewSelector[Order](db).From(t5).Select(t1.C("UsingCol1"), t1.C("UsingCol2"))
 			}(),
@@ -1601,10 +1509,10 @@ func TestSelector_Join(t *testing.T) {
 			// SELECT t1.xxx, t2.xxx
 			name: "join table C-C invalid",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t3.Join(t4).On(t2.C("ItemId").EQ(t4.C("Id")))
 				return NewSelector[Order](db).From(t5).Select(t1.C("invalid"), t1.C("invalid"))
 			}(),
@@ -1613,12 +1521,12 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "table join",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t4.Join(t3).On(t2.C("ItemId").EQ(t4.C("Id")))
-				return NewSelector[Order](db).From(t5)
+				return NewSelector[Order](db).Select(t4.AllColumns()).From(t5)
 			}(),
 			wantQuery: &Query{
 				SQL: "SELECT `t4`.* FROM (`item` AS `t4` JOIN (`order` AS `t1` JOIN `order_detail` AS `t2` ON `t1`.`id`=`t2`.`order_id`) ON `t2`.`item_id`=`t4`.`id`);",
@@ -1627,22 +1535,22 @@ func TestSelector_Join(t *testing.T) {
 		{
 			name: "table join on Sum",
 			s: func() QueryBuilder {
-				t1 := TableOf(&Order{}).As("t1")
-				t2 := TableOf(&OrderDetail{}).As("t2")
+				t1 := TableOf(&Order{}, "t1")
+				t2 := TableOf(&OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
-				t4 := TableOf(&Item{}).As("t4")
+				t4 := TableOf(&Item{}, "t4")
 				t5 := t4.Join(t3).On(t2.C("ItemId").EQ(t4.C("Id")))
-				return NewSelector[Order](db).From(t5).Select(t4.Sum("Id").As("Id"), t4.Min("Id").As("Id"), t4.Max("Id").As("Id"), t4.Sum("Id").As("Id"), t4.Count("Id").As("Id"))
+				return NewSelector[Order](db).From(t5).Select(t4.Sum("Id").As("sum_id"), t4.Min("Id").As("min_id"), t4.Max("Id").As("max_id"), t4.Sum("Id").As("t4_sum_id"), t4.Count("Id").As("t4_cnt_id"))
 			}(),
 			wantQuery: &Query{
-				SQL: "SELECT SUM(`t4`.`id`) AS `Id`,MIN(`t4`.`id`) AS `Id`,MAX(`t4`.`id`) AS `Id`,SUM(`t4`.`id`) AS `Id`,COUNT(`t4`.`id`) AS `Id` FROM (`item` AS `t4` JOIN (`order` AS `t1` JOIN `order_detail` AS `t2` ON `t1`.`id`=`t2`.`order_id`) ON `t2`.`item_id`=`t4`.`id`);",
+				SQL: "SELECT SUM(`t4`.`id`) AS `sum_id`,MIN(`t4`.`id`) AS `min_id`,MAX(`t4`.`id`) AS `max_id`,SUM(`t4`.`id`) AS `t4_sum_id`,COUNT(`t4`.`id`) AS `t4_cnt_id` FROM (`item` AS `t4` JOIN (`order` AS `t1` JOIN `order_detail` AS `t2` ON `t1`.`id`=`t2`.`order_id`) ON `t2`.`item_id`=`t4`.`id`);",
 			},
 		},
 		{
 			name: "table join col",
 			s: func() QueryBuilder {
-				t1 := TableOf(&test.Order{}).As("t1")
-				t2 := TableOf(&test.OrderDetail{}).As("t2")
+				t1 := TableOf(&test.Order{}, "t1")
+				t2 := TableOf(&test.OrderDetail{}, "t2")
 				t3 := t1.Join(t2).On(t1.C("Id").EQ(t2.C("OrderId")))
 				return NewSelector[test.Order](db).From(t3).Select(t1.Avg("UsingCol1").As("UsingCol1"))
 			}(),

--- a/table.go
+++ b/table.go
@@ -15,6 +15,7 @@
 package eorm
 
 type TableReference interface {
+	getAlias() string
 }
 
 // Table 普通表
@@ -23,10 +24,18 @@ type Table struct {
 	alias  string
 }
 
-func TableOf(entity any) Table {
+// TableOf 创建一个 Table 代表一个表
+// alias 是指该表的别名
+// 例如 SELECT * FROM user_tab AS t1，t1 就是别名
+func TableOf(entity any, alias string) Table {
 	return Table{
 		entity: entity,
+		alias:  alias,
 	}
+}
+
+func (t Table) getAlias() string {
+	return t.alias
 }
 
 // Join 查询
@@ -51,13 +60,6 @@ func (t Table) RightJoin(right TableReference) *JoinBuilder {
 		left:  t,
 		right: right,
 		typ:   "RIGHT JOIN",
-	}
-}
-
-func (t Table) As(alias string) Table {
-	return Table{
-		entity: t.entity,
-		alias:  alias,
 	}
 }
 
@@ -123,6 +125,10 @@ type Join struct {
 	on    []Predicate
 	using []string
 	typ   string
+}
+
+func (Join) getAlias() string {
+	return ""
 }
 
 func (j Join) Join(reference TableReference) *JoinBuilder {

--- a/update_test.go
+++ b/update_test.go
@@ -99,10 +99,10 @@ func TestUpdater_Set(t *testing.T) {
 			wantArgs: []interface{}{"Tom", 10},
 		},
 		{
-			name:     "set age=id+(age*100)",
-			builder:  NewUpdater[TestModel](orm).Update(tm).Set(C("FirstName"), Assign("Age", C("Id").Add(C("Age").Multi(100)))),
-			wantSql:  "UPDATE `test_model` SET `first_name`=?,`age`=(`id`+(`age`*?));",
-			wantArgs: []interface{}{"Tom", 100},
+			name:     "set age=id+(age*100)+10",
+			builder:  NewUpdater[TestModel](orm).Update(tm).Set(C("FirstName"), Assign("Age", C("Id").Add(C("Age").Multi(100)).Add(10))),
+			wantSql:  "UPDATE `test_model` SET `first_name`=?,`age`=((`id`+(`age`*?))+?);",
+			wantArgs: []interface{}{"Tom", 100, 10},
 		},
 		{
 			name:     "set age=(id+(age*100))*110",


### PR DESCRIPTION
- TableOf 必须指定别名：一方面这算是我比较推荐的一个实践，即 SQL 里面给表一个别名这样可读性会更高；另外一方面是为了避免在实现过程中，我们需要频繁去检测是否有别名的问题
- JOIN 或者将来的子查询之类的，必须要指定返回的列：实际上最开始的方案，是搜索最左边的 Table 的列。但是这并不是一个和那好的设计。首先对于用户来说，他难以理解为什么要用最左边；其次，最佳的方案应该是找到第一个是泛型类型的那个的所有的列；